### PR TITLE
Reduce the footprint of including ink-wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux \
     && cargo --version \
     && rustc --version \
     && apt-get remove -y --auto-remove wget \
+    && apt-get -y install gcc \
     && rm -rf /var/lib/apt/lists/*
 
 FROM slimmed-rust as cc-builder
@@ -55,10 +56,6 @@ RUN rm -rf cargo-contract
 # Generate ink! types from contract metadata with ink-wrapper
 #
 FROM slimmed-rust as ink-wrapper-builder
-
-# Needed for 'cc' linking
-RUN apt-get update && apt-get -y install gcc \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install ink-wrapper
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN rm -rf cargo-contract
 #
 # Generate ink! types from contract metadata with ink-wrapper
 #
-FROM slimmed-rust as ink-wrapper
+FROM slimmed-rust as ink-wrapper-builder
 
 # Needed for 'cc' linking
 RUN apt-get update && apt-get -y install gcc \
@@ -65,9 +65,10 @@ RUN cargo install ink-wrapper
 #
 # ink! 4.0 optimizer
 # 
-FROM ink-wrapper as ink-dev
+FROM slimmed-rust as ink-dev
 
 COPY --from=cc-builder /usr/local/bin/cargo-contract /usr/local/bin/cargo-contract
+COPY --from=ink-wrapper-builder /usr/local/cargo/bin/ink-wrapper /usr/local/bin/ink-wrapper
 
 WORKDIR /code
 


### PR DESCRIPTION
Uses the same trick we use for cargo-contract - builds in a temporary, throwaway image and copies only the binary into the final image.