### PR TITLE
Bump cargo-contract version and docker tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV RUSTFLAGS="-C target-feature=-crt-static"
 RUN apt-get -y update && apt-get -y install gcc g++ git
 
 # Use https instead of git so that we don't have to install required for using git://
-RUN git clone --depth 1 --branch v2.0.0 https://github.com/paritytech/cargo-contract.git
+RUN git clone --depth 1 --branch v2.1.0 https://github.com/paritytech/cargo-contract.git
 
 WORKDIR ${PWD}/cargo-contract
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 1.1.0
+DOCKER_TAG := 1.2.0
 
 # Native arch
 BUILDARCH := $(shell uname -m)


### PR DESCRIPTION
This PR bumps cargo contract to 2.1.0 in the tool. It also bumps the docker tag to 1.2.0. Default behavior of the `docker push` seems to overwrite our already-existing tags in the ECR.