### PR TITLE
Lock ink-wrapper version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN rm -rf cargo-contract
 #
 FROM slimmed-rust as ink-wrapper-builder
 
-RUN cargo install ink-wrapper --version 0.4.1 --locked --force
+RUN cargo install ink-wrapper --version 0.4.1 --locked
 
 #
 # ink! 4.0 optimizer

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN rm -rf cargo-contract
 #
 FROM slimmed-rust as ink-wrapper-builder
 
-RUN cargo install ink-wrapper
+RUN cargo install ink-wrapper --version 0.4.1 --locked --force
 
 #
 # ink! 4.0 optimizer

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 1.2.0
+DOCKER_TAG := 1.3.0
 
 # Native arch
 BUILDARCH := $(shell uname -m)


### PR DESCRIPTION
This changes the way `ink-wrapper` is installed in containers, locking the version and forcing an update.