### PR TITLE
Use (specific) nightly toolchain to install `ink-wrapper`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ RUN rm -rf cargo-contract
 #
 FROM slimmed-rust as ink-wrapper-builder
 
-RUN cargo install ink-wrapper --version ${INK_WRAPPER_VERSION} --locked --force
+RUN rustup toolchain install nightly-2023-04-16 \
+   && cargo +nightly-2023-04-16 install ink-wrapper --version ${INK_WRAPPER_VERSION} --locked --force
 
 #
 # ink! 4.0 optimizer


### PR DESCRIPTION
Otherwise usage of ink-wrapper fails due to unformatted output.

I'm not bumping tag here on purpose, the previously published `1.7.0` is not really usable (due to the problems with `ink-wrapper`) and so it should be removed. The way GH docker action works though is that if the second push to registry uses an already-used version, it will overwrite it anyway so if we merge this PR we should automatically "fix" the `1.7.0`.