### PR TITLE
Use branch'd `ink-wrapper` for compatibility with aleph-node 12.1 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN set -eux \
     && apt-get update && apt-get -y install wget \
     && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
-    amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
-    arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
-    *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac \
     && url="https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init" \
     && wget "$url" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.71.0 \
-    CARGO_CONTRACT_VERSION=3.2.0
+    CARGO_CONTRACT_VERSION=3.2.0 \
+    INK_WRAPPER_VERSION=57fde9f0e31f1de610efe1879715c028849f4bc0
 
 LABEL cargo-contract="$CARGO_CONTRACT_VERSION" \
-    rust="$RUST_VERSION"
+    rust="$RUST_VERSION" \
+    ink-wrapper="rev-$INK_WRAPPER_VERSION"
 
 # Minimal Rust dependencies.
 RUN set -eux \
@@ -62,7 +64,7 @@ RUN rm -rf cargo-contract
 FROM slimmed-rust as ink-wrapper-builder
 
 RUN rustup toolchain install nightly-2023-04-20 \
-    && cargo +nightly-2023-04-20 install ink-wrapper --git https://github.com/Cardinal-Cryptography/ink-wrapper.git --branch aleph-client-compat --locked --force
+    && cargo +nightly-2023-04-20 install ink-wrapper --git https://github.com/Cardinal-Cryptography/ink-wrapper.git --rev ${INK_WRAPPER_VERSION} --locked --force
 
 #
 # ink! 4.0 optimizer

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,19 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.71.0 \
-    CARGO_CONTRACT_VERSION=3.2.0 \
-    INK_WRAPPER_VERSION=0.6.1
+    CARGO_CONTRACT_VERSION=3.2.0
 
 LABEL cargo-contract="$CARGO_CONTRACT_VERSION" \
-    rust="$RUST_VERSION" \
-    ink-wrapper="$INK_WRAPPER_VERSION"
+    rust="$RUST_VERSION"
 
 # Minimal Rust dependencies.
 RUN set -eux \
     && apt-get update && apt-get -y install wget \
     && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
+    arm64) rustArch='aarch64-unknown-linux-gnu' ;; \
+    *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac \
     && url="https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init" \
     && wget "$url" \
@@ -64,7 +62,7 @@ RUN rm -rf cargo-contract
 FROM slimmed-rust as ink-wrapper-builder
 
 RUN rustup toolchain install nightly-2023-04-20 \
-    && cargo +nightly-2023-04-20 install ink-wrapper --version ${INK_WRAPPER_VERSION} --locked --force
+    && cargo +nightly-2023-04-20 install ink-wrapper --git https://github.com/Cardinal-Cryptography/ink-wrapper.git --branch aleph-client-compat --locked --force
 
 #
 # ink! 4.0 optimizer

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 1.8.0-r12.1
+DOCKER_TAG := 1.8.0-r12.1-57fde9
 
 # Native arch
 BUILDARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 1.8.0-r12.1-57fde9
+DOCKER_TAG := 2.0.0
 
 # Native arch
 BUILDARCH := $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 1.8.0
+DOCKER_TAG := 1.8.0-r12.1
 
 # Native arch
 BUILDARCH := $(shell uname -m)


### PR DESCRIPTION
This PR updates `ink-wrapper`, installed in the `ink-dev` image, to install the version from the feature branch where it's compatible with `aleph-node` release `r-12.1`. We cannot release `ink-wrapper` to crates ATM since `aleph_client`'s releases after version `3.0.0` are no longer pushed to the crates. I chose to install via `--rev` so that later changes to the feature branch (which will definitely come) don't alter the state of the image.

It also adds docker labels and bumps toolchain used to install ink-wrapper.

[Here](https://github.com/Cardinal-Cryptography/ink-wrapper/compare/main...aleph-client-compat) you can find changes made to the `ink-wrapper`.