### PR TITLE
Install new ink-wrapper version and bump docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM docker.io/bitnami/minideb:bullseye as slimmed-rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.71.0 \
+    RUST_VERSION=1.72.0 \
     CARGO_CONTRACT_VERSION=3.2.0 \
-    INK_WRAPPER_VERSION=57fde9f0e31f1de610efe1879715c028849f4bc0
+    INK_WRAPPER_VERSION=0.8.0
 
 LABEL cargo-contract="$CARGO_CONTRACT_VERSION" \
     rust="$RUST_VERSION" \
@@ -63,8 +63,7 @@ RUN rm -rf cargo-contract
 #
 FROM slimmed-rust as ink-wrapper-builder
 
-RUN rustup toolchain install nightly-2023-04-20 \
-    && cargo +nightly-2023-04-20 install ink-wrapper --git https://github.com/Cardinal-Cryptography/ink-wrapper.git --rev ${INK_WRAPPER_VERSION} --locked --force
+RUN cargo install ink-wrapper --version ${INK_WRAPPER_VERSION} --locked --force
 
 #
 # ink! 4.0 optimizer

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 MAKEFILE_NAME := Ink development docker
 DOCKER_NAME_INK_DEV := cardinal-cryptography/ink-dev
-DOCKER_TAG := 2.0.1
+DOCKER_TAG := 2.1.0
 
 # Native arch
 BUILDARCH := $(shell uname -m)


### PR DESCRIPTION
Updates docker-ink-dev image to install the new ink-wrapper(-types) versions compatible with DRink! backend.